### PR TITLE
Add transport_query() method on Client

### DIFF
--- a/jack.py
+++ b/jack.py
@@ -681,12 +681,9 @@ class Client(object):
                "Error locating JACK transport")
 
     def transport_query(self):
-        """return current transport position."""
-        # Test rolling transport status
-        if _lib.jack_transport_query(self._ptr, self._position) == 1:
-            return self._position
-        else:
-            return None
+        """return current transport state and position."""
+        transport_state = _lib.jack_transport_query(self._ptr, self._position)
+        return Transport(transport_state, self._position)
 
     def set_freewheel(self, onoff):
         """Start/Stop JACK's "freewheel" mode.
@@ -1981,6 +1978,166 @@ class Status(object):
     def _hasflag(self, flag):
         """Helper function for Status properties."""
         return bool(self._code & flag)
+
+
+class Transport():
+
+    """Representation of the Jack transport state and position"""
+
+    # transport state values
+    STOPPED = _lib.JackTransportStopped
+    ROLLING = _lib.JackTransportRolling
+    LOOPING = _lib.JackTransportLooping
+    STARTING = _lib.JackTransportStarting
+    NETSTARTING = _lib.JackTransportNetStarting
+
+    # Transport position valid fields flags
+    BBT = 0x10
+    TIMECODE = 0x20
+    BBTFRAMEOFFSET = 0x40
+
+    def __init__(self, transport_state, cffi_position):
+        self._state = transport_state
+        self._position = cffi_position
+
+    @property
+    def state(self):
+        """Current state of transport."""
+        return self._state
+
+    # Position getters
+    @property
+    def usecs(self):
+        return self._position.usecs
+
+    @property
+    def frame_rate(self):
+        return self._position.frame_rate
+
+    @property
+    def frame(self):
+        return self._position.frame
+
+    @property
+    def valid(self):
+        return self._position.valid
+
+    @property
+    def bar(self):
+        return self._position.bar
+
+    @property
+    def beat(self):
+        return self._position.beat
+
+    @property
+    def tick(self):
+        return self._position.tick
+
+    @property
+    def bar_start_tick(self):
+        return self._position.bar_start_tick
+
+    @property
+    def beats_per_bar(self):
+        return self._position.beats_per_bar
+
+    @property
+    def beat_type(self):
+        return self._position.beat_type
+
+    @property
+    def ticks_per_beat(self):
+        return self._position.ticks_per_beat
+
+    @property
+    def beats_per_minute(self):
+        return self._position.beats_per_minute
+
+    @property
+    def frame_time(self):
+        return self._position.frame_time
+
+    @property
+    def next_time(self):
+        return self._position.next_time
+
+    @property
+    def bbt_offset(self):
+        return self._position.bbt_offset
+
+    @property
+    def transport_info(self):
+        """Return all transport informations
+
+        Return a dict with following keys :
+          Transport Status :
+            * state : transport state : STOPPED, ROLLING, ...
+          Transport position fields :
+            * usecs : monotonic, free-rolling
+            * frame_rate : current frame rate (per second)
+            * frame : frame number (frame count since transport start)
+          BBT fields :
+            * bar: current bar
+            * beat: current beat-within-bar
+            * tick: current tick-within-beat
+            * bar_start_tick : ?
+            * bbt_offset : frame offset for the BBT fields (see below)
+          time signature fields :
+            * beats_per_bar : time signature "numerator"
+            * beat_type : time signature "denominator"
+            * ticks_per_beat : ticks per beat
+            * beats_per_minute : current tempo (BPM)
+          timecode fields :
+            * frame_time : current time in seconds
+            * next_time : next sequential frame_time (unless repositioned)
+
+        About bbt_offset : frame offset for the BBT fields (the given bar,
+        beat, and tick values actually refer to a time frame_offset frames
+        before the start of the cycle), should be assumed to be 0 if
+        JackBBTFrameOffset is not set. If JackBBTFrameOffset is set and this
+        value is zero, the BBT time refers to the first frame of this cycle. If
+        the value is positive, the BBT time refers to a frame that many frames
+        before the start of the cycle.
+
+        Jack video positional data are not copied to dict"""
+
+        # Check consistency of data
+        # if self._position.unique_1 == 0:
+        #    raise JackError("Zero unique ID")
+        if self._position.unique_1 != self._position.unique_2:
+            raise JackError("Unique unique not matching : {} <> {}".
+                            format(self._position.unique_1,
+                                   self._position.unique_2))
+
+        # Populate dict
+        res = {}
+        res['state'] = self.state
+        res['usecs'] = self.usecs
+        res['frame_rate'] = self.frame_rate
+        res['frame'] = self.frame
+
+        # Check if BBT fields are present
+        if self.valid & self.BBT:
+            res['bar'] = self.bar
+            res['beat'] = self.beat
+            res['tick'] = self.tick
+            res['bar_start_tick'] = self.bar_start_tick
+            res['beats_per_bar'] = self.beats_per_bar
+            res['beat_type'] = self.beat_type
+            res['ticks_per_beat'] = self.ticks_per_beat
+            res['beats_per_minute'] = self.beats_per_minute
+
+        # check if Timecode fields are present
+        if self.valid & self.TIMECODE:
+            res['frame_time'] = self.frame_time
+            res['next_time'] = self.next_time
+
+        # check BBT Frame offset field
+        if self.valid & self.BBTFRAMEOFFSET:
+            res['bbt_offset'] = self.bbt_offset
+
+        return res
 
 
 class JackError(Exception):

--- a/jack.py
+++ b/jack.py
@@ -96,10 +96,9 @@ typedef uint64_t jack_unique_t;
 typedef enum {
     JackPositionBBT = 0x10,
     JackPositionTimecode = 0x20,
-    JackBBTFrameOffset =      0x40,
-    JackAudioVideoRatio =     0x80,
-    JackVideoFrameOffset =   0x100
-
+    JackBBTFrameOffset = 0x40,
+    JackAudioVideoRatio = 0x80,
+    JackVideoFrameOffset = 0x100,
 } jack_position_bits_t;
 struct _jack_position {
     jack_unique_t       unique_1;

--- a/jack.py
+++ b/jack.py
@@ -681,9 +681,52 @@ class Client(object):
                "Error locating JACK transport")
 
     def transport_query(self):
-        """return current transport state and position."""
+        """return current transport state and position.
+
+        Return a tuple with current transport state and position informations
+
+        Transport state
+        ---------------
+        Transport state can take following value :
+            * 0 : Stopped
+            * 1 : Rolling (playing)
+            * 2 : Looping
+            * 3 : Starting (preparing playback)
+            * 4 : Net Starting
+
+        Position informations
+        ---------------------
+        Position information are stored in CFFI object. This object have
+        following attribute :
+            * usecs : monotonic, free-rolling
+            * frame_rate : current frame rate (per second)
+            * frame : frame number (frame count since transport start)
+            * valid : indicate which fields are present and valid (see below)
+            * bar: current bar
+            * beat: current beat-within-bar
+            * tick: current tick-within-beat
+            * bar_start_tick
+            * bbt_offset : frame offset for the BBT fields (see below)
+            * beats_per_bar : time signature "numerator"
+            * beat_type : time signature "denominator"
+            * ticks_per_beat : ticks per beat
+            * beats_per_minute : current tempo (BPM)
+            * frame_time : current time in seconds
+            * next_time : next sequential frame_time (unless repositioned)
+            * audio_frames_per_video_frame
+            * video_offset
+
+        valid field is can take following values (bit flag) :
+            * 0x10 : bar, beat, tick, bar_start_tick, beats_per_bar,
+                     beat_type, ticks_per_beat, beats_per_minute
+            * 0x20 : frame_time, next_time
+            * 0x40 : bbt_offset
+            * 0x80 : audio_frames_per_video_frame
+            * 0x100 : video_offset
+
+        """
         transport_state = _lib.jack_transport_query(self._ptr, self._position)
-        return Transport(transport_state, self._position)
+        return transport_state, self._position
 
     def set_freewheel(self, onoff):
         """Start/Stop JACK's "freewheel" mode.
@@ -1980,164 +2023,6 @@ class Status(object):
         return bool(self._code & flag)
 
 
-class Transport():
-
-    """Representation of the Jack transport state and position"""
-
-    # transport state values
-    STOPPED = _lib.JackTransportStopped
-    ROLLING = _lib.JackTransportRolling
-    LOOPING = _lib.JackTransportLooping
-    STARTING = _lib.JackTransportStarting
-    NETSTARTING = _lib.JackTransportNetStarting
-
-    # Transport position valid fields flags
-    BBT = 0x10
-    TIMECODE = 0x20
-    BBTFRAMEOFFSET = 0x40
-
-    def __init__(self, transport_state, cffi_position):
-        self._state = transport_state
-        self._position = cffi_position
-
-    @property
-    def state(self):
-        """Current state of transport."""
-        return self._state
-
-    # Position getters
-    @property
-    def usecs(self):
-        return self._position.usecs
-
-    @property
-    def frame_rate(self):
-        return self._position.frame_rate
-
-    @property
-    def frame(self):
-        return self._position.frame
-
-    @property
-    def valid(self):
-        return self._position.valid
-
-    @property
-    def bar(self):
-        return self._position.bar
-
-    @property
-    def beat(self):
-        return self._position.beat
-
-    @property
-    def tick(self):
-        return self._position.tick
-
-    @property
-    def bar_start_tick(self):
-        return self._position.bar_start_tick
-
-    @property
-    def beats_per_bar(self):
-        return self._position.beats_per_bar
-
-    @property
-    def beat_type(self):
-        return self._position.beat_type
-
-    @property
-    def ticks_per_beat(self):
-        return self._position.ticks_per_beat
-
-    @property
-    def beats_per_minute(self):
-        return self._position.beats_per_minute
-
-    @property
-    def frame_time(self):
-        return self._position.frame_time
-
-    @property
-    def next_time(self):
-        return self._position.next_time
-
-    @property
-    def bbt_offset(self):
-        return self._position.bbt_offset
-
-    @property
-    def transport_info(self):
-        """Return all transport informations
-
-        Return a dict with following keys :
-          Transport Status :
-            * state : transport state : STOPPED, ROLLING, ...
-          Transport position fields :
-            * usecs : monotonic, free-rolling
-            * frame_rate : current frame rate (per second)
-            * frame : frame number (frame count since transport start)
-          BBT fields :
-            * bar: current bar
-            * beat: current beat-within-bar
-            * tick: current tick-within-beat
-            * bar_start_tick : ?
-            * bbt_offset : frame offset for the BBT fields (see below)
-          time signature fields :
-            * beats_per_bar : time signature "numerator"
-            * beat_type : time signature "denominator"
-            * ticks_per_beat : ticks per beat
-            * beats_per_minute : current tempo (BPM)
-          timecode fields :
-            * frame_time : current time in seconds
-            * next_time : next sequential frame_time (unless repositioned)
-
-        About bbt_offset : frame offset for the BBT fields (the given bar,
-        beat, and tick values actually refer to a time frame_offset frames
-        before the start of the cycle), should be assumed to be 0 if
-        JackBBTFrameOffset is not set. If JackBBTFrameOffset is set and this
-        value is zero, the BBT time refers to the first frame of this cycle. If
-        the value is positive, the BBT time refers to a frame that many frames
-        before the start of the cycle.
-
-        Jack video positional data are not copied to dict"""
-
-        # Check consistency of data
-        # if self._position.unique_1 == 0:
-        #    raise JackError("Zero unique ID")
-        if self._position.unique_1 != self._position.unique_2:
-            raise JackError("Unique unique not matching : {} <> {}".
-                            format(self._position.unique_1,
-                                   self._position.unique_2))
-
-        # Populate dict
-        res = {}
-        res['state'] = self.state
-        res['usecs'] = self.usecs
-        res['frame_rate'] = self.frame_rate
-        res['frame'] = self.frame
-
-        # Check if BBT fields are present
-        if self.valid & self.BBT:
-            res['bar'] = self.bar
-            res['beat'] = self.beat
-            res['tick'] = self.tick
-            res['bar_start_tick'] = self.bar_start_tick
-            res['beats_per_bar'] = self.beats_per_bar
-            res['beat_type'] = self.beat_type
-            res['ticks_per_beat'] = self.ticks_per_beat
-            res['beats_per_minute'] = self.beats_per_minute
-
-        # check if Timecode fields are present
-        if self.valid & self.TIMECODE:
-            res['frame_time'] = self.frame_time
-            res['next_time'] = self.next_time
-
-        # check BBT Frame offset field
-        if self.valid & self.BBTFRAMEOFFSET:
-            res['bbt_offset'] = self.bbt_offset
-
-        return res
 
 
 class JackError(Exception):

--- a/jack.py
+++ b/jack.py
@@ -100,30 +100,6 @@ typedef enum {
     JackAudioVideoRatio = 0x80,
     JackVideoFrameOffset = 0x100,
 } jack_position_bits_t;
-struct _jack_position {
-    jack_unique_t       unique_1;
-    jack_time_t         usecs;
-    jack_nframes_t      frame_rate;
-    jack_nframes_t      frame;
-    jack_position_bits_t valid;
-    int32_t             bar;
-    int32_t             beat;
-    int32_t             tick;
-    double              bar_start_tick;
-    float               beats_per_bar;
-    float               beat_type;
-    double              ticks_per_beat;
-    double              beats_per_minute;
-    double              frame_time;
-    double              next_time;
-    jack_nframes_t      bbt_offset;
-    float               audio_frames_per_video_frame;
-    jack_nframes_t      video_offset;
-    int32_t             padding[7];
-    jack_unique_t       unique_2;
-};
-
-typedef struct _jack_position jack_position_t;
 
 /* jack.h */
 
@@ -221,9 +197,7 @@ void jack_free(void* ptr);
 /* transport.h */
 
 int  jack_transport_locate(jack_client_t* client, jack_nframes_t frame);
-jack_transport_state_t jack_transport_query(const jack_client_t* client, jack_position_t* pos);
 jack_nframes_t jack_get_current_transport_frame(const jack_client_t* client);
-int  jack_transport_reposition(jack_client_t* client, const jack_position_t* pos);
 void jack_transport_start(jack_client_t* client);
 void jack_transport_stop(jack_client_t* client);
 
@@ -253,6 +227,35 @@ uint32_t jack_midi_get_lost_event_count(void* port_buffer);
 
 #define EEXIST 17
 """)
+
+# Packed structure
+_ffi.cdef("""
+struct _jack_position {
+    jack_unique_t       unique_1;
+    jack_time_t         usecs;
+    jack_nframes_t      frame_rate;
+    jack_nframes_t      frame;
+    jack_position_bits_t valid;
+    int32_t             bar;
+    int32_t             beat;
+    int32_t             tick;
+    double              bar_start_tick;
+    float               beats_per_bar;
+    float               beat_type;
+    double              ticks_per_beat;
+    double              beats_per_minute;
+    double              frame_time;
+    double              next_time;
+    jack_nframes_t      bbt_offset;
+    float               audio_frames_per_video_frame;
+    jack_nframes_t      video_offset;
+    int32_t             padding[7];
+    jack_unique_t       unique_2;
+};
+typedef struct _jack_position jack_position_t;
+jack_transport_state_t jack_transport_query(const jack_client_t* client, jack_position_t* pos);
+int  jack_transport_reposition(jack_client_t* client, const jack_position_t* pos);
+""", packed=True)
 
 _lib = _ffi.dlopen("jack")
 

--- a/jack.py
+++ b/jack.py
@@ -355,7 +355,6 @@ class Client(object):
 
         """
         status = _ffi.new("jack_status_t*")
-        self.position = _ffi.new("jack_position_t*")
         args = [name.encode(), _lib.JackNullOption, status]
         if use_exact_name:
             args[1] |= _lib.JackUseExactName
@@ -377,6 +376,7 @@ class Client(object):
         self._midi_inports = Ports(self, _MIDI, _lib.JackPortIsInput)
         self._midi_outports = Ports(self, _MIDI, _lib.JackPortIsOutput)
         self._keepalive = []
+        self._position = _ffi.new("jack_position_t*")
 
     # Avoid confusion if something goes wrong before opening the client:
     _ptr = _ffi.NULL
@@ -683,8 +683,8 @@ class Client(object):
     def transport_query(self):
         """return current transport position."""
         # Test rolling transport status
-        if _lib.jack_transport_query(self._ptr, self.position) == 1:
-            return self.position
+        if _lib.jack_transport_query(self._ptr, self._position) == 1:
+            return self._position
         else:
             return None
 

--- a/jack.py
+++ b/jack.py
@@ -34,7 +34,7 @@ _ffi.cdef("""
 
 typedef uint64_t jack_uuid_t;
 typedef uint32_t jack_nframes_t;
-/* TODO: jack_time_t */
+typedef uint64_t jack_time_t;
 typedef struct _jack_port jack_port_t;
 typedef struct _jack_client jack_client_t;
 typedef uint32_t jack_port_id_t;
@@ -93,82 +93,35 @@ typedef enum {
     JackTransportNetStarting = 4,
 } jack_transport_state_t;
 typedef uint64_t jack_unique_t;
-typedef uint64_t jack_time_t;
-typedef uint32_t jack_nframes_t;
 typedef enum {
-
-    JackPositionBBT = 0x10,     /**< Bar, Beat, Tick */
-    JackPositionTimecode = 0x20,        /**< External timecode */
-    JackBBTFrameOffset =      0x40,     /**< Frame offset of BBT information */
-    JackAudioVideoRatio =     0x80, /**< audio frames per video frame */
-    JackVideoFrameOffset =   0x100  /**< frame offset of first video frame */
+    JackPositionBBT = 0x10,
+    JackPositionTimecode = 0x20,
+    JackBBTFrameOffset =      0x40,
+    JackAudioVideoRatio =     0x80,
+    JackVideoFrameOffset =   0x100
 
 } jack_position_bits_t;
-
 struct _jack_position {
-    jack_unique_t       unique_1;       /**< unique ID */
-    jack_time_t         usecs;          /**< monotonic, free-rolling */
-    jack_nframes_t      frame_rate;     /**< current frame rate (per second) */
-    jack_nframes_t      frame;          /**< frame number, always present */
-
-    jack_position_bits_t valid;         /**< which other fields are valid */
-
-    /* JackPositionBBT fields: */
-    int32_t             bar;            /**< current bar */
-    int32_t             beat;           /**< current beat-within-bar */
-    int32_t             tick;           /**< current tick-within-beat */
+    jack_unique_t       unique_1;
+    jack_time_t         usecs;
+    jack_nframes_t      frame_rate;
+    jack_nframes_t      frame;
+    jack_position_bits_t valid;
+    int32_t             bar;
+    int32_t             beat;
+    int32_t             tick;
     double              bar_start_tick;
-
-    float               beats_per_bar;  /**< time signature "numerator" */
-    float               beat_type;      /**< time signature "denominator" */
+    float               beats_per_bar;
+    float               beat_type;
     double              ticks_per_beat;
     double              beats_per_minute;
-
-    /* JackPositionTimecode fields:     (EXPERIMENTAL: could change) */
-    double              frame_time;     /**< current time in seconds */
-    double              next_time;      /**< next sequential frame_time
-                         (unless repositioned) */
-
-    /* JackBBTFrameOffset fields: */
-    jack_nframes_t      bbt_offset;     /**< frame offset for the BBT fields
-                         (the given bar, beat, and tick
-                         values actually refer to a time
-                         frame_offset frames before the
-                         start of the cycle), should
-                         be assumed to be 0 if
-                         JackBBTFrameOffset is not
-                         set. If JackBBTFrameOffset is
-                         set and this value is zero, the BBT
-                         time refers to the first frame of this
-                         cycle. If the value is positive,
-                         the BBT time refers to a frame that
-                         many frames before the start of the
-                         cycle. */
-
-    /* JACK video positional data (experimental) */
-
-    float               audio_frames_per_video_frame; /**< number of audio frames
-                         per video frame. Should be assumed
-                         zero if JackAudioVideoRatio is not
-                         set. If JackAudioVideoRatio is set
-                         and the value is zero, no video
-                         data exists within the JACK graph */
-
-    jack_nframes_t      video_offset;   /**< audio frame at which the first video
-                         frame in this cycle occurs. Should
-                         be assumed to be 0 if JackVideoFrameOffset
-                         is not set. If JackVideoFrameOffset is
-                         set, but the value is zero, there is
-                         no video frame within this cycle. */
-
-    /* For binary compatibility, new fields should be allocated from
-     * this padding area with new valid bits controlling access, so
-     * the existing structure size and offsets are preserved. */
+    double              frame_time;
+    double              next_time;
+    jack_nframes_t      bbt_offset;
+    float               audio_frames_per_video_frame;
+    jack_nframes_t      video_offset;
     int32_t             padding[7];
-
-    /* When (unique_1 == unique_2) the contents are consistent. */
-    jack_unique_t       unique_2;       /**< unique ID */
-
+    jack_unique_t       unique_2;
 };
 
 typedef struct _jack_position jack_position_t;
@@ -2021,8 +1974,6 @@ class Status(object):
     def _hasflag(self, flag):
         """Helper function for Status properties."""
         return bool(self._code & flag)
-
-
 
 
 class JackError(Exception):


### PR DESCRIPTION
Hello, 

I added transport_query() method in order to get current transport position and BPM.

I added several C types from /usr/include/jack/types.h
package : libjack-jackd2-dev 1.9.9.5+201306 (Linux Mint 17.1 64bit)
I also added a new attribute to Client class : 'position' to avoid malloc() in transport_query() method
