### PR TITLE
Make the return values of Client.transport_query() more Pythonic

### DIFF
--- a/jack.py
+++ b/jack.py
@@ -676,6 +676,20 @@ class Client(object):
         """Stop JACK transport."""
         _lib.jack_transport_stop(self._ptr)
 
+    @property
+    def transport_state(self):
+        """JACK transport state.
+
+        This is one of :attr:`STOPPED`, :attr:`ROLLING`,
+        :attr:`STARTING`, :attr:`NETSTARTING`.
+
+        See Also
+        --------
+        transport_query
+
+        """
+        return TransportState(_lib.jack_transport_query(self._ptr, _ffi.NULL))
+
     def transport_locate(self, frame):
         """Reposition the JACK transport to a new frame number.
 
@@ -704,6 +718,10 @@ class Client(object):
         position : dict
             A dictionary containing only the valid fields of the
             structure returned by :meth:`transport_query_struct`.
+
+        See Also
+        --------
+        :attr:`transport_state`
 
         """
         state, pos = self.transport_query_struct()

--- a/jack.py
+++ b/jack.py
@@ -2160,9 +2160,13 @@ def _make_statusbase():
 
     names = set(['__gt__', '__ge__'])
     names.update(numbers.Integral.__abstractmethods__)
-    methods = dict((name, redirect(name)) for name in names)
-    methods.update({'__eq__': lambda self, other: int(self) == other})
-    return type("_StatusBase", (), methods)
+    namespace = dict((name, redirect(name)) for name in names)
+    namespace.update({
+        '__slots__': '_code',
+        '__init__': lambda self, code: setattr(self, '_code', code),
+        '__eq__': lambda self, other: int(self) == other,
+    })
+    return type("_StatusBase", (), namespace)
 
 _StatusBase = _make_statusbase()
 del _make_statusbase
@@ -2172,8 +2176,7 @@ class Status(_StatusBase):
 
     """Representation of the JACK status bits."""
 
-    def __init__(self, statuscode):
-        self._code = statuscode
+    __slots__ = ()
 
     def __repr__(self):
         flags = ", ".join(name for name in dir(self)


### PR DESCRIPTION
I want to rename `transport_query()` to `transport_query_struct()` to still have a low-overhead way to get the information, which might probably even be somewhat realtime safe.

Any suggestions for a better name?

Then I want to implement a new `transport_query()` method which calls the old `transport_query_struct()` and prepares the results to be nicer to handle:

* Create a `jack.TransportState` class to wrap the "state" integer
  * return an instance of this class from `transport_query()`
  * change the module constants (e.g. `jack.ROLLING`) to instances of this class

* Convert the fields from the `jack_position_t` struct into a Python `dict` that only contains the valid information