### PR TITLE
Add warning about realtime processing with Python

### DIFF
--- a/examples/midi_monitor.py
+++ b/examples/midi_monitor.py
@@ -12,7 +12,6 @@ port = client.midi_inports.register("input")
 @client.set_process_callback
 def process(frames):
     for offset, data in port.incoming_midi_events():
-        # TODO: use ringbuffer
         print("{0}: 0x{1}".format(client.last_frame_time + offset,
                                   binascii.hexlify(data).decode()))
     return jack.CALL_AGAIN

--- a/jack.py
+++ b/jack.py
@@ -851,6 +851,23 @@ class Client(object):
         pthread_mutex_lock, sleep, wait, poll, select, pthread_join,
         pthread_cond_wait, etc, etc.
 
+        .. warning:: Most Python interpreters use a `global interpreter
+           lock (GIL)`__, which violates the above real-time
+           requirement.  Furthermore, Python's `garbage collector`__
+           might become active at an inconvenient time and block the
+           process callback for some time.
+
+           Because of this, Python is not really suitable for real-time
+           processing.  If you want to implement a *reliable* real-time
+           audio/MIDI application, you should use a different
+           programming language, such as C or C++.
+
+           If you can live with some random audio drop-outs now and
+           then, feel free to continue using Python!
+
+        __ http://en.wikipedia.org/wiki/Global_Interpreter_Lock
+        __ http://en.wikipedia.org/wiki/Garbage_collection_(computer_science)
+
         .. note:: This function cannot be called while the client is
            activated (after :meth:`activate` has been called).
 


### PR DESCRIPTION
I think it was clear from the beginning that Python isn't really the go-to platform for realtime audio processing.
I think it is still interesting to have the possibility to use JACK's realtime features, even if they may not be very reliable.

But I think it's important to note this in the documentation, thus the PR.

Any comments?

Suggestions for improvements?