### PR TITLE
Use CallbackExit exception instead of callback return values

### DIFF
--- a/examples/chatty_client.py
+++ b/examples/chatty_client.py
@@ -53,13 +53,11 @@ def freewheel(starting):
 @client.set_blocksize_callback
 def blocksize(blocksize):
     print("setting blocksize to", blocksize)
-    return jack.SUCCESS
 
 
 @client.set_samplerate_callback
 def samplerate(samplerate):
     print("setting samplerate to", samplerate)
-    return jack.SUCCESS
 
 
 @client.set_client_registration_callback
@@ -81,7 +79,6 @@ try:
     @client.set_port_rename_callback
     def port_rename(port, old, new):
         print("renamed", port, "from", repr(old), "to", repr(new))
-        return jack.SUCCESS
 except AttributeError:
     print("Could not register port rename callback (not available on JACK1).")
 
@@ -89,13 +86,11 @@ except AttributeError:
 @client.set_graph_order_callback
 def graph_order():
     print("graph order changed")
-    return jack.SUCCESS
 
 
 @client.set_xrun_callback
 def xrun():
     print("xrun; delay", client.xrun_delayed_usecs, "microseconds")
-    return jack.SUCCESS
 
 
 print("activating JACK")

--- a/examples/midi_chords.py
+++ b/examples/midi_chords.py
@@ -32,7 +32,6 @@ def process(frames):
                 for i in INTERVALS:
                     # Note: This may raise an exception:
                     outport.write_midi_event(offset, (status, pitch + i, vel))
-    return jack.CALL_AGAIN
 
 with client:
     print("#" * 80)

--- a/examples/midi_monitor.py
+++ b/examples/midi_monitor.py
@@ -14,7 +14,6 @@ def process(frames):
     for offset, data in port.incoming_midi_events():
         print("{0}: 0x{1}".format(client.last_frame_time + offset,
                                   binascii.hexlify(data).decode()))
-    return jack.CALL_AGAIN
 
 with client:
     print("#" * 80)

--- a/examples/midi_sine.py
+++ b/examples/midi_sine.py
@@ -122,7 +122,6 @@ def process(frames):
     dead = [k for k, v in voices.items() if v.weight <= 0]
     for pitch in dead:
         del voices[pitch]
-    return jack.CALL_AGAIN
 
 
 @client.set_samplerate_callback
@@ -130,7 +129,6 @@ def samplerate(samplerate):
     global fs
     fs = samplerate
     voices.clear()
-    return jack.SUCCESS
 
 
 @client.set_shutdown_callback

--- a/examples/thru_client.py
+++ b/examples/thru_client.py
@@ -47,7 +47,6 @@ def process(frames):
     assert frames == client.blocksize
     for i, o in zip(client.inports, client.outports):
         o.get_buffer()[:] = i.get_buffer()
-    return jack.CALL_AGAIN
 
 
 @client.set_shutdown_callback


### PR DESCRIPTION
The idea is based on a part of #16, namely ba4d5fc0f78a3982f9a12b403c4722331b0d6deb.

None of the callbacks is supposed to have a return value anymore, instead they are supposed to raise `jack.CallbackExit` on error.