### PR TITLE
Make TransportState class hashable

### DIFF
--- a/src/jack.py
+++ b/src/jack.py
@@ -1747,7 +1747,7 @@ class Port(object):
 
     def unset_alias(self, alias):
         """Remove an alias for the JACK port.
-        
+
         If the alias doesn't exist this function will return an error.
 
         """
@@ -2598,6 +2598,9 @@ class TransportState(object):
 
     def __eq__(self, other):
         return self._code == other
+
+    def __hash__(self):
+        return hash(self._code)
 
     def __repr__(self):
         return 'jack.' + {


### PR DESCRIPTION
This allows instances to be used as dict keys, without breaking encapsulation by accessing the internal attribute `_code` directly.

Signed-off-by: Christopher Arndt <chris@chrisarndt.de>