### PR TITLE
Add 'sphinx_rtd_theme' to doc requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 Jinja2
 Pygments
 Sphinx>=1.3
+sphinx_rtd_theme


### PR DESCRIPTION
With newer Sphinx versions you get the following error on `python setup.py build_sphinx`, if `sphinx_rtd_theme` is not installed explicitly:

```
Theme error:
sphinx_rtd_theme is no longer a hard dependency since version 1.4.0. Please install it manually.(pip install sphinx_rtd_theme)
```

Signed-off-by: Christopher Arndt <chris@chrisarndt.de>