### PR TITLE
Add errno attribute to JackError exception

### DIFF
--- a/src/jack.py
+++ b/src/jack.py
@@ -159,6 +159,11 @@ class Client(object):
             Pass a SessionID Token. This allows the sessionmanager to
             identify the client again.
 
+        Raises
+        ------
+        JackOpenError
+            If the session with the JACK server could not be opened.
+
         """
         status = _ffi.new('jack_status_t*')
         options = _lib.JackNullOption
@@ -209,7 +214,14 @@ class Client(object):
 
     @property
     def uuid(self):
-        """The UUID of the JACK client (read-only)."""
+        """The UUID of the JACK client (read-only).
+
+        Raises
+        ------
+        JackError
+            If getting the UUID fails.
+
+        """
         uuid = _ffi.gc(_lib.jack_client_get_uuid(self._ptr), _lib.jack_free)
         if not uuid:
             raise JackError('Unable to get UUID')
@@ -438,6 +450,12 @@ class Client(object):
         See Also
         --------
         OwnPort.connect, disconnect
+
+        Raises
+        ------
+        JackError
+            If there is already an existing connection between *source* and
+            *destination* or the connection can not be established.
 
         """
         if isinstance(source, Port):
@@ -1438,6 +1456,11 @@ class Client(object):
         The session manager needs this to reassociate a client name to
         the session ID.
 
+        Raises
+        ------
+        JackError
+            If no client with the given name exists.
+
         """
         uuid = _ffi.gc(_lib.jack_get_uuid_for_client_name(
             self._ptr, name.encode()), _lib.jack_free)
@@ -1451,6 +1474,11 @@ class Client(object):
         In order to snapshot the graph connections, the session manager
         needs to map session IDs to client names.
 
+        Raises
+        ------
+        JackError
+            If no client with the given UUID exists.
+
         """
         name = _ffi.gc(_lib.jack_get_client_name_by_uuid(
             self._ptr, uuid.encode()), _lib.jack_free)
@@ -1463,6 +1491,11 @@ class Client(object):
 
         Given a full port name, this returns a `Port`, `MidiPort`,
         `OwnPort` or `OwnMidiPort` object.
+
+        Raises
+        ------
+        JackError
+            If no port with the given name exists.
 
         """
         port_ptr = _lib.jack_port_by_name(self._ptr, name.encode())
@@ -1678,7 +1711,15 @@ class Client(object):
         return callback_decorator
 
     def _register_port(self, name, porttype, is_terminal, is_physical, flags):
-        """Create a new port."""
+        """Create a new port.
+
+        Raises
+        ------
+        JackError
+            If the port can not be registered, e.g. because the name is
+            non-unique or too long.
+
+        """
         if is_terminal:
             flags |= _lib.JackPortIsTerminal
         if is_physical:
@@ -2329,6 +2370,12 @@ class RingBuffer(object):
             size (rounded up to the next power of 2), but one byte is
             reserved for internal use.  Use `write_space` to
             determine the actual size available for writing.
+
+
+        Raises
+        ------
+        JackError
+            If the rightbufefr could not be allocated.
 
         """
         ptr = _lib.jack_ringbuffer_create(size)

--- a/src/jack.py
+++ b/src/jack.py
@@ -141,7 +141,7 @@ class Client(object):
         self._status = Status(status[0])
         if not self._ptr:
             raise JackError('Error initializing "{0}": {1}'.format(
-                name, self.status))
+                name, self.status), errno=status[0])
 
         self._inports = Ports(self, _AUDIO, _lib.JackPortIsInput)
         self._outports = Ports(self, _AUDIO, _lib.JackPortIsOutput)
@@ -411,7 +411,8 @@ class Client(object):
                                 destination.encode())
         if err == _errno.EEXIST:
             raise JackError('Connection {0!r} -> {1!r} '
-                            'already exists'.format(source, destination))
+                            'already exists'.format(source, destination),
+                            errno=err)
         _check(err,
                'Error connecting {0!r} -> {1!r}'.format(source, destination))
 
@@ -2642,7 +2643,18 @@ class TransportState(object):
 class JackError(Exception):
     """Exception for all kinds of JACK-related errors."""
 
-    pass
+    def __init__(self, msg, errno=None):
+        """Initialize new exception instance.
+
+        Parameters
+        ----------
+        errno : int, optional
+            The error or status code returned by the JACK library function,
+            which resulted in this exception being raised. Defaults to `None`.
+
+        """
+        super().__init__(msg)
+        self.errno = errno
 
 
 class CallbackExit(Exception):
@@ -2915,4 +2927,4 @@ _keepalive = {}
 def _check(error_code, msg):
     """Check error code and raise JackError if non-zero."""
     if error_code:
-        raise JackError('{0} ({1})'.format(msg, error_code))
+        raise JackError('{0} ({1})'.format(msg, error_code), errno=error_code)

--- a/src/jack.py
+++ b/src/jack.py
@@ -109,9 +109,9 @@ class JackOpenError(JackError):
 
         Parameters
         ----------
-        status : int
-            A `Status` instance representing the status information received
-            by the `jack_client_open` JACK library call. This will be
+        status : :class:`Status`
+            A :class:`Status` instance representing the status information
+            received by the `jack_client_open` JACK library call. This will be
             accessible via the `status` attribute of the exception instance.
 
         """


### PR DESCRIPTION
Makes it possible to determine the exact cause of a `JackError` exception by looking at the `errno` attribute of exception instances, instead of having to rely on parsing the exception's error message.

For instance, if creating a `jack.Client` fails, since no `Client` instance is created, the `<client>.status` property is not available. With this change, one could use the `errno` to check the status:

```python
try:
    client = jack.Client('my-client')
except JackError as e:
   status = jack.Status(e.errno))
   if status.server_failed:
      ...
   elif status.version_error:
      ...
```

For other instances of this exception, `errno` is set to the error code returned by the JACK library function, whose call was not successful.

```python
try:
    client.outports[0].write_midi_event(time, event)
except JackError as e:
    if e.errno == errno.ENOBUFS:
         ...
```

I chose to call the attribute `errno`, because some built-in exceptions use this name too, but it could be easily changed.

Signed-off-by: Christopher Arndt <chris@chrisarndt.de>