### PR TITLE
DOC: Add PyPI/docs/diff links to NEWS

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,40 +1,76 @@
-Version 0.5.2 (2020-02-11):
+Version 0.5.2 -- 2020-02-11 -- PyPI__ -- docs__ -- diff__
  * new module constants: ``jack.POSITION_*``
  * new examples: ``timebase_master.py`` and ``transporter.py``,
    thanks to Christopher Arndt
  * new `jack.JackError` subclasses: `jack.JackErrorCode` and `jack.JackOpenError`,
    thanks to Christopher Arndt
 
-Version 0.5.1 (2019-11-07):
+__ https://pypi.org/project/JACK-Client/0.5.2/
+__ https://jackclient-python.readthedocs.io/en/0.5.2/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.5.1...0.5.2
+
+Version 0.5.1 -- 2019-11-07 -- PyPI__ -- docs__ -- diff__
  * `jack.Client.release_timebase()`, thanks to Christopher Arndt
 
-Version 0.5.0 (2019-07-18):
+__ https://pypi.org/project/JACK-Client/0.5.1/
+__ https://jackclient-python.readthedocs.io/en/0.5.1/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.5.0...0.5.1
+
+Version 0.5.0 -- 2019-07-18 -- PyPI__ -- docs__ -- diff__
  * drop Python 2 support
  * support for metadata API, with the help of Christopher Arndt
  * support for slow-sync clients
 
-Version 0.4.6 (2019-02-09):
+__ https://pypi.org/project/JACK-Client/0.5.0/
+__ https://jackclient-python.readthedocs.io/en/0.5.0/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.4.6...0.5.0
+
+Version 0.4.6 -- 2019-02-09 -- PyPI__ -- docs__ -- diff__
  * ``midi_file_player.py`` example
 
-Version 0.4.5 (2018-09-02):
+__ https://pypi.org/project/JACK-Client/0.4.6/
+__ https://jackclient-python.readthedocs.io/en/0.4.6/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.4.5...0.4.6
+
+Version 0.4.5 -- 2018-09-02 -- PyPI__ -- docs__ -- diff__
  * Fix issue #54; other minor improvements
 
-Version 0.4.4 (2018-02-19):
+__ https://pypi.org/project/JACK-Client/0.4.5/
+__ https://jackclient-python.readthedocs.io/en/0.4.5/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.4.4...0.4.5
+
+Version 0.4.4 -- 2018-02-19 -- PyPI__ -- docs__ -- diff__
  * `Port.set_alias()`, `Port.unset_alias()` and `Port.aliases`, thanks to
    Jośe Fernando Moyano
 
-Version 0.4.3 (2017-12-30):
+__ https://pypi.org/project/JACK-Client/0.4.4/
+__ https://jackclient-python.readthedocs.io/en/0.4.4/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.4.3...0.4.4
+
+Version 0.4.3 -- 2017-12-30 -- PyPI__ -- docs__ -- diff__
  * switch to CFFI out-of-line ABI mode (to reduce import time)
 
-Version 0.4.2 (2016-11-05):
+__ https://pypi.org/project/JACK-Client/0.4.3/
+__ https://jackclient-python.readthedocs.io/en/0.4.3/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.4.2...0.4.3
+
+Version 0.4.2 -- 2016-11-05 -- PyPI__ -- docs__ -- diff__
  * new examples: ``showtime.py``, ``midi_sine_numpy.py`` and ``play_file.py``
  * new option ``only_available`` for port callbacks
 
-Version 0.4.1 (2016-05-24):
+__ https://pypi.org/project/JACK-Client/0.4.2/
+__ https://jackclient-python.readthedocs.io/en/0.4.2/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.4.1...0.4.2
+
+Version 0.4.1 -- 2016-05-24 -- PyPI__ -- docs__ -- diff__
  * new property `jack.Client.transport_frame`, deprecating
    `jack.Client.transport_locate()`
 
-Version 0.4.0 (2015-09-17):
+__ https://pypi.org/project/JACK-Client/0.4.1/
+__ https://jackclient-python.readthedocs.io/en/0.4.1/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.4.0...0.4.1
+
+Version 0.4.0 -- 2015-09-17 -- PyPI__ -- docs__ -- diff__
  * new argument to xrun callback (see `jack.Client.set_xrun_callback()`),
    ``jack.Client.xrun_delayed_usecs`` was removed
  * `jack.Client.transport_reposition_struct()`
@@ -42,7 +78,11 @@ Version 0.4.0 (2015-09-17):
    `jack.CallbackExit` on error
  * ``midi_sine.py`` example
 
-Version 0.3.0 (2015-07-16):
+__ https://pypi.org/project/JACK-Client/0.4.0/
+__ https://jackclient-python.readthedocs.io/en/0.4.0/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.3.0...0.4.0
+
+Version 0.3.0 -- 2015-07-16 -- PyPI__ -- docs__ -- diff__
  * `jack.RingBuffer`, implemented by Alexandru Stan
  * `jack.Client.set_timebase_callback()`, `jack.Client.transport_query()`,
    `jack.Client.transport_query_struct()`, with the help of Julien Acroute
@@ -52,7 +92,11 @@ Version 0.3.0 (2015-07-16):
  * compatibility with the official JACK installer for Windows, thanks to Julien
    Acroute
 
-Version 0.2.0 (2015-02-23):
+__ https://pypi.org/project/JACK-Client/0.3.0/
+__ https://jackclient-python.readthedocs.io/en/0.3.0/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.2.0...0.3.0
+
+Version 0.2.0 -- 2015-02-23 -- PyPI__ -- docs__ -- diff__
  * MIDI support (`jack.MidiPort`, `jack.OwnMidiPort`,
    `jack.Client.midi_inports`, `jack.Client.midi_outports`, ...)
  * ignore errors in `jack.Client.deactivate()` by default, can be overridden
@@ -62,5 +106,12 @@ Version 0.2.0 (2015-02-23):
  * `jack.Port.is_physical`, courtesy of Alexandru Stan
  * `jack.Status`
 
-Version 0.1.0 (2014-12-15):
+__ https://pypi.org/project/JACK-Client/0.2.0/
+__ https://jackclient-python.readthedocs.io/en/0.2.0/
+__ https://github.com/spatialaudio/jackclient-python/compare/0.1.0...0.2.0
+
+Version 0.1.0 -- 2014-12-15 -- PyPI__ -- docs__
    Initial release
+
+__ https://pypi.org/project/JACK-Client/0.1.0/
+__ https://jackclient-python.readthedocs.io/en/0.1.0/


### PR DESCRIPTION
Rendered: https://jackclient-python--96.org.readthedocs.build/en/96/version-history.html