### PR TITLE
fix port listing crash when a port is removed during the listing

### DIFF
--- a/src/jack.py
+++ b/src/jack.py
@@ -1773,7 +1773,17 @@ class Client:
                 name = names[idx]
                 if not name:
                     break
-                ports.append(self.get_port_by_name(_decode(name)))
+
+                port_ptr = _lib.jack_port_by_name(self._ptr, name)
+                if not port_ptr:
+                    continue
+
+                try:
+                    port = self._wrap_port_ptr(port_ptr)
+                except AssertionError:
+                    continue
+
+                ports.append(port)
                 idx += 1
         return ports
 


### PR DESCRIPTION
Hi.

I meet this crash several times with the method Client.get_ports() :

```
    for port in self.client.get_ports():
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/jack.py", line 1598, in get_ports
    return self._port_list_from_pointers(names)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/jack.py", line 1773, in _port_list_from_pointers
    ports.append(self.get_port_by_name(_decode(name)))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/jack.py", line 1533, in get_port_by_name
    raise JackError('Port {0!r} not available'.format(name))
jack.JackError: Port 'Carla-Rack.rack:audio-in1' not available
```

The port name is not always the same. It happens when I switch from a (ray) session to another, many clients are quitting. It is very very probable that port has been destroyed during listing.

This patch fixes the problem with the choice to not raise any exception in this case, if port has gone, it must not be listed.